### PR TITLE
[azure-messaging-eventhubs-cpp] Shorten source paths

### DIFF
--- a/ports/azure-messaging-eventhubs-cpp/00100-shorten_paths.patch
+++ b/ports/azure-messaging-eventhubs-cpp/00100-shorten_paths.patch
@@ -1,0 +1,350 @@
+diff --git a/sdk/eventhubs/CMakeLists.txt b/sdk/eventhubs/CMakeLists.txt
+index 4cf10b5b..bcf386ab 100644
+--- a/sdk/eventhubs/CMakeLists.txt
++++ b/sdk/eventhubs/CMakeLists.txt
+@@ -8,4 +8,4 @@ set(CMAKE_CXX_STANDARD 14)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ 
+-add_subdirectory(azure-messaging-eventhubs)
++add_subdirectory(eventhubs)
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md b/sdk/eventhubs/eventhubs/CHANGELOG.md
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+rename to sdk/eventhubs/eventhubs/CHANGELOG.md
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/CMakeLists.txt b/sdk/eventhubs/eventhubs/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/LICENSE b/sdk/eventhubs/eventhubs/LICENSE
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/LICENSE
+rename to sdk/eventhubs/eventhubs/LICENSE
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/README.md b/sdk/eventhubs/eventhubs/README.md
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/README.md
+rename to sdk/eventhubs/eventhubs/README.md
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/ApiViewSettings.json b/sdk/eventhubs/eventhubs/inc/ApiViewSettings.json
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/ApiViewSettings.json
+rename to sdk/eventhubs/eventhubs/inc/ApiViewSettings.json
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/checkpoint_store.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/checkpoint_store.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/checkpoint_store.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/checkpoint_store.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/consumer_client.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/dll_import_export.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/dll_import_export.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/dll_import_export.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/dll_import_export.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/event_data_batch.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/eventhubs_exception.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/eventhubs_exception.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/eventhubs_exception.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/eventhubs_exception.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/checkpoint_store_models.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/checkpoint_store_models.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/checkpoint_store_models.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/checkpoint_store_models.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/consumer_client_models.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/consumer_client_models.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/consumer_client_models.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/consumer_client_models.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/event_data.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/event_data.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/event_data.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/event_data.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/management_models.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/management_models.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/management_models.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/management_models.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/partition_client_models.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/partition_client_models.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/partition_client_models.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/partition_client_models.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/processor_load_balancer_models.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/processor_load_balancer_models.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/processor_load_balancer_models.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/processor_load_balancer_models.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/processor_models.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/processor_models.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/models/processor_models.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/models/processor_models.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/partition_client.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/partition_client.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/partition_client.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/partition_client.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/processor.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/processor.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor_load_balancer.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/processor_load_balancer.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor_load_balancer.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/processor_load_balancer.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor_partition_client.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/processor_partition_client.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/processor_partition_client.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/processor_partition_client.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/producer_client.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/rtti.hpp b/sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/rtti.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/inc/azure/messaging/eventhubs/rtti.hpp
+rename to sdk/eventhubs/eventhubs/inc/azure/messaging/eventhubs/rtti.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/CMakeLists.txt b/sdk/eventhubs/eventhubs/samples/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/samples/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/README.md b/sdk/eventhubs/eventhubs/samples/README.md
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/README.md
+rename to sdk/eventhubs/eventhubs/samples/README.md
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/CMakeLists.txt b/sdk/eventhubs/eventhubs/samples/basic-operations/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/samples/basic-operations/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp b/sdk/eventhubs/eventhubs/samples/basic-operations/create_consumer.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer.cpp
+rename to sdk/eventhubs/eventhubs/samples/basic-operations/create_consumer.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer_aad.cpp b/sdk/eventhubs/eventhubs/samples/basic-operations/create_consumer_aad.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_consumer_aad.cpp
+rename to sdk/eventhubs/eventhubs/samples/basic-operations/create_consumer_aad.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp b/sdk/eventhubs/eventhubs/samples/basic-operations/create_producer.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer.cpp
+rename to sdk/eventhubs/eventhubs/samples/basic-operations/create_producer.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer_aad.cpp b/sdk/eventhubs/eventhubs/samples/basic-operations/create_producer_aad.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/basic-operations/create_producer_aad.cpp
+rename to sdk/eventhubs/eventhubs/samples/basic-operations/create_producer_aad.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/CMakeLists.txt b/sdk/eventhubs/eventhubs/samples/consume-events/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/samples/consume-events/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp b/sdk/eventhubs/eventhubs/samples/consume-events/consume_events.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events.cpp
+rename to sdk/eventhubs/eventhubs/samples/consume-events/consume_events.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events_aad.cpp b/sdk/eventhubs/eventhubs/samples/consume-events/consume_events_aad.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/consume-events/consume_events_aad.cpp
+rename to sdk/eventhubs/eventhubs/samples/consume-events/consume_events_aad.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/CMakeLists.txt b/sdk/eventhubs/eventhubs/samples/produce-events/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/samples/produce-events/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp b/sdk/eventhubs/eventhubs/samples/produce-events/produce_events.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events.cpp
+rename to sdk/eventhubs/eventhubs/samples/produce-events/produce_events.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events_aad.cpp b/sdk/eventhubs/eventhubs/samples/produce-events/produce_events_aad.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/samples/produce-events/produce_events_aad.cpp
+rename to sdk/eventhubs/eventhubs/samples/produce-events/produce_events_aad.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/checkpoint_store.cpp b/sdk/eventhubs/eventhubs/src/checkpoint_store.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/checkpoint_store.cpp
+rename to sdk/eventhubs/eventhubs/src/checkpoint_store.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp b/sdk/eventhubs/eventhubs/src/consumer_client.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/consumer_client.cpp
+rename to sdk/eventhubs/eventhubs/src/consumer_client.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/event_data.cpp b/sdk/eventhubs/eventhubs/src/event_data.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/event_data.cpp
+rename to sdk/eventhubs/eventhubs/src/event_data.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/event_data_batch.cpp b/sdk/eventhubs/eventhubs/src/event_data_batch.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/event_data_batch.cpp
+rename to sdk/eventhubs/eventhubs/src/event_data_batch.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/eventhubs_utilities.cpp b/sdk/eventhubs/eventhubs/src/eventhubs_utilities.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/eventhubs_utilities.cpp
+rename to sdk/eventhubs/eventhubs/src/eventhubs_utilities.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/partition_client.cpp b/sdk/eventhubs/eventhubs/src/partition_client.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/partition_client.cpp
+rename to sdk/eventhubs/eventhubs/src/partition_client.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/partition_client_models.cpp b/sdk/eventhubs/eventhubs/src/partition_client_models.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/partition_client_models.cpp
+rename to sdk/eventhubs/eventhubs/src/partition_client_models.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_constants.hpp b/sdk/eventhubs/eventhubs/src/private/eventhubs_constants.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_constants.hpp
+rename to sdk/eventhubs/eventhubs/src/private/eventhubs_constants.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp b/sdk/eventhubs/eventhubs/src/private/eventhubs_utilities.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/private/eventhubs_utilities.hpp
+rename to sdk/eventhubs/eventhubs/src/private/eventhubs_utilities.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/private/package_version.hpp b/sdk/eventhubs/eventhubs/src/private/package_version.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/private/package_version.hpp
+rename to sdk/eventhubs/eventhubs/src/private/package_version.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp b/sdk/eventhubs/eventhubs/src/private/retry_operation.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/private/retry_operation.hpp
+rename to sdk/eventhubs/eventhubs/src/private/retry_operation.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/processor_load_balancer.cpp b/sdk/eventhubs/eventhubs/src/processor_load_balancer.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/processor_load_balancer.cpp
+rename to sdk/eventhubs/eventhubs/src/processor_load_balancer.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/processor_partition_client.cpp b/sdk/eventhubs/eventhubs/src/processor_partition_client.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/processor_partition_client.cpp
+rename to sdk/eventhubs/eventhubs/src/processor_partition_client.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp b/sdk/eventhubs/eventhubs/src/producer_client.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/producer_client.cpp
+rename to sdk/eventhubs/eventhubs/src/producer_client.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp b/sdk/eventhubs/eventhubs/src/retry_operation.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/src/retry_operation.cpp
+rename to sdk/eventhubs/eventhubs/src/retry_operation.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test-resources-post.ps1 b/sdk/eventhubs/eventhubs/test-resources-post.ps1
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test-resources-post.ps1
+rename to sdk/eventhubs/eventhubs/test-resources-post.ps1
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test-resources.json b/sdk/eventhubs/eventhubs/test-resources.json
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test-resources.json
+rename to sdk/eventhubs/eventhubs/test-resources.json
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/CMakeLists.txt b/sdk/eventhubs/eventhubs/test/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/test/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/.dockerignore b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/.dockerignore
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/.dockerignore
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/.dockerignore
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/.helmignore b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/.helmignore
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/.helmignore
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/.helmignore
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/CMakeLists.txt b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/Chart.lock b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/Chart.lock
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/Chart.lock
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/Chart.lock
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/Chart.yaml b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/Chart.yaml
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/Chart.yaml
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/Chart.yaml
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/Dockerfile b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/Dockerfile
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/Dockerfile
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/Dockerfile
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/README.md b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/README.md
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/README.md
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/README.md
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/deploy.ps1 b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/deploy.ps1
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/deploy.ps1
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/deploy.ps1
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/eventhubs_stress_test.cpp b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/eventhubs_stress_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/eventhubs_stress_test.cpp
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/eventhubs_stress_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/scenarios-matrix.yaml b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/scenarios-matrix.yaml
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/scenarios-matrix.yaml
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/scenarios-matrix.yaml
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/stress-test-resources.bicep b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/stress-test-resources.bicep
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/stress-test-resources.bicep
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/stress-test-resources.bicep
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/templates/deploy-job.yaml b/sdk/eventhubs/eventhubs/test/eventhubs-stress-test/templates/deploy-job.yaml
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/eventhubs-stress-test/templates/deploy-job.yaml
+rename to sdk/eventhubs/eventhubs/test/eventhubs-stress-test/templates/deploy-job.yaml
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/perf/CMakeLists.txt b/sdk/eventhubs/eventhubs/test/perf/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/perf/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/test/perf/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp b/sdk/eventhubs/eventhubs/test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp
+rename to sdk/eventhubs/eventhubs/test/perf/inc/azure/messaging/eventhubs/test/eventhubs_batch_perf_test.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/perf/src/azure_eventhubs_perf_test.cpp b/sdk/eventhubs/eventhubs/test/perf/src/azure_eventhubs_perf_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/perf/src/azure_eventhubs_perf_test.cpp
+rename to sdk/eventhubs/eventhubs/test/perf/src/azure_eventhubs_perf_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/CMakeLists.txt b/sdk/eventhubs/eventhubs/test/ut/CMakeLists.txt
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/CMakeLists.txt
+rename to sdk/eventhubs/eventhubs/test/ut/CMakeLists.txt
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/checkpoint_store_test.cpp b/sdk/eventhubs/eventhubs/test/ut/checkpoint_store_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/checkpoint_store_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/checkpoint_store_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp b/sdk/eventhubs/eventhubs/test/ut/consumer_client_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/consumer_client_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/consumer_client_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/event_data_test.cpp b/sdk/eventhubs/eventhubs/test/ut/event_data_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/event_data_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/event_data_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_test_base.hpp b/sdk/eventhubs/eventhubs/test/ut/eventhubs_test_base.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/eventhubs_test_base.hpp
+rename to sdk/eventhubs/eventhubs/test/ut/eventhubs_test_base.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_load_balancer_test.cpp b/sdk/eventhubs/eventhubs/test/ut/processor_load_balancer_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_load_balancer_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/processor_load_balancer_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_test.cpp b/sdk/eventhubs/eventhubs/test/ut/processor_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/processor_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/processor_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp b/sdk/eventhubs/eventhubs/test/ut/producer_client_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/producer_client_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/producer_client_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp b/sdk/eventhubs/eventhubs/test/ut/retry_operation_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/retry_operation_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/retry_operation_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/round_trip_test.cpp b/sdk/eventhubs/eventhubs/test/ut/round_trip_test.cpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/round_trip_test.cpp
+rename to sdk/eventhubs/eventhubs/test/ut/round_trip_test.cpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/test/ut/test_checkpoint_store.hpp b/sdk/eventhubs/eventhubs/test/ut/test_checkpoint_store.hpp
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/test/ut/test_checkpoint_store.hpp
+rename to sdk/eventhubs/eventhubs/test/ut/test_checkpoint_store.hpp
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg.json b/sdk/eventhubs/eventhubs/vcpkg.json
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/vcpkg.json
+rename to sdk/eventhubs/eventhubs/vcpkg.json
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/Config.cmake.in b/sdk/eventhubs/eventhubs/vcpkg/Config.cmake.in
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/vcpkg/Config.cmake.in
+rename to sdk/eventhubs/eventhubs/vcpkg/Config.cmake.in
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake b/sdk/eventhubs/eventhubs/vcpkg/portfile.cmake
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/vcpkg/portfile.cmake
+rename to sdk/eventhubs/eventhubs/vcpkg/portfile.cmake
+diff --git a/sdk/eventhubs/azure-messaging-eventhubs/vcpkg/vcpkg.json b/sdk/eventhubs/eventhubs/vcpkg/vcpkg.json
+similarity index 100%
+rename from sdk/eventhubs/azure-messaging-eventhubs/vcpkg/vcpkg.json
+rename to sdk/eventhubs/eventhubs/vcpkg/vcpkg.json

--- a/ports/azure-messaging-eventhubs-cpp/portfile.cmake
+++ b/ports/azure-messaging-eventhubs-cpp/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO Azure/azure-sdk-for-cpp
     REF azure-messaging-eventhubs_1.0.0-beta.2
     SHA512 3677edf50218c39e378a968661c0ec0600b8760d3af33f204f3267e104449c0aef42b9520cb63b5e5810b89bf91f06979d009ffdd6d6d04d2c14e1a21f0e111f
+    PATCHES
+        00100-shorten_paths.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/azure-messaging-eventhubs-cpp/vcpkg.json
+++ b/ports/azure-messaging-eventhubs-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-messaging-eventhubs-cpp",
   "version-semver": "1.0.0-beta.2",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Messaging Event Hubs SDK for C++",
     "This library provides Azure Messaging Event Hubs SDK."

--- a/versions/a-/azure-messaging-eventhubs-cpp.json
+++ b/versions/a-/azure-messaging-eventhubs-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57afed23bac62d99d7db9a329c822e26c5acd79e",
+      "version-semver": "1.0.0-beta.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "983c9c2a6615afc22cd76bdbbef3f403a608bbbf",
       "version-semver": "1.0.0-beta.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -438,7 +438,7 @@
     },
     "azure-messaging-eventhubs-cpp": {
       "baseline": "1.0.0-beta.2",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-security-attestation-cpp": {
       "baseline": "1.1.0",


### PR DESCRIPTION
Windows has a path limit of 260 characters, and certain packages fail to build when depending on azure-messaging-eventhubs.
This change patches the directory names and it does not change any public surface available to the port users.